### PR TITLE
Fix multi-layer initrd extraction for modern distros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,27 +7,28 @@ RUN \
  echo "**** install deps ****" && \
  apt-get update && \
  apt-get install -y \
-	cpio \
-	curl \
+        cpio \
+        curl \
         file \
-	jq \
+        initramfs-tools-core \
+        jq \
         libarchive-tools \
-	liblz4-tool \
-	p7zip-full \
-	psmisc \
-	transmission-cli \
+        liblz4-tool \
+        p7zip-full \
+        psmisc \
+        transmission-cli \
         xxd \
-	xz-utils \
-	zstd && \
+        xz-utils \
+        zstd && \
  echo "**** directories ****" && \
  mkdir -p \
-	/buildout \
-	/root/Downloads && \
+        /buildout \
+        /root/Downloads && \
  echo "**** clean up ****" && \
  rm -rf \
-	/tmp/* \
-	/var/lib/apt/lists/* \
-	/var/tmp/*
+        /tmp/* \
+        /var/lib/apt/lists/* \
+        /var/tmp/*
 
 # add local files
 COPY /root /


### PR DESCRIPTION
This commit fixes a critical bug in initrd extraction that was causing kernel modules and drivers to be lost when extracting multi-layer initrds used by modern distributions.

Problem:
--------
The existing extraction logic assumed initrds were either:
1. Single microcode layer + compressed cpio archive, OR
2. Multiple microcode layers to strip before reaching compressed data

However, modern distros (Ubuntu 25.04+, Debian, Clonezilla, etc.) use a 3-layer structure:
- Layer 1 (early): AMD/Intel microcode (cpio)
- Layer 2 (early2): Kernel modules/drivers (cpio with .ko.zst files)
- Layer 3 (main): Main initramfs (zstd compressed cpio)

The old logic would strip layers using dd with block counts from cpio metadata, but this approach:
- Only extracted layer 1 (microcode)
- Lost layer 2 (ALL kernel drivers/modules - ~1000+ .ko files)
- Only decompressed layer 3 (main initramfs)

This resulted in network-booted systems missing critical drivers for:
- Network cards (e1000e, r8169, igb, etc.)
- Storage controllers (nvme, ahci, etc.)
- USB devices
- Graphics drivers

Solution:
---------
1. Add initramfs-tools-core to Dockerfile for unmkinitramfs tool
2. Use unmkinitramfs as primary extraction method
   - Properly handles all initrd layer types
   - Preserves all layers including kernel modules
   - Standard tool designed for this exact purpose
3. Keep old manual extraction as fallback for compatibility
4. Add detailed logging to show which layers are being merged

Benefits:
---------
- Fixes Clonezilla builds (issue discovered in netbootxyz/ubuntu-squash)
- Ensures all kernel modules/drivers are preserved
- More robust and maintainable
- Better error handling
- Backwards compatible with single-layer initrds

Testing:
--------
Tested with:
- Clonezilla 20251017-questing (3-layer initrd)
- Verified all 1000+ kernel modules preserved in early2 layer
- Confirmed network boot functionality
