### PR TITLE
Support arbitrary part counts when splitting large assets

### DIFF
--- a/root/build.sh
+++ b/root/build.sh
@@ -16,12 +16,11 @@ if [[ "${COMPRESS_INITRD}" == "true" ]];then
   while read -r MOVE; do
     DEST="${MOVE#*|}"
     mv /buildin/${DEST} /buildout/
-    if [[ -f "/buildin/${DEST}.part2" ]]; then
-      mv /buildin/${DEST}.part2 /buildout/
-    fi
-    if [[ -f "/buildin/${DEST}.part3" ]]; then
-      mv /buildin/${DEST}.part3 /buildout/
-    fi
+    i=2
+    while [[ -f "/buildin/${DEST}.part${i}" ]]; do
+      mv /buildin/${DEST}.part${i} /buildout/
+      i=$((i+1))
+    done
   done <<< "${CONTENTS}"
   # compress initrd folder into bootable file
   cd /buildin/initrd_files
@@ -66,11 +65,15 @@ while read -r MOVE; do
   filesize=$(du -b ${SRC} | awk '{print $1}')
   if [[ ${filesize} -gt 2097152000 ]]; then
     split -b 2097151999 ${SRC}
-    mv xaa /buildout/"${DEST}"
-    mv xab /buildout/"${DEST}".part2
-    if [[ -f "xac" ]]; then
-      mv xac /buildout/"${DEST}".part3
-    fi
+    i=0
+    for chunk in $(ls x?? 2>/dev/null | sort); do
+      i=$((i+1))
+      if [[ ${i} -eq 1 ]]; then
+        mv "${chunk}" /buildout/"${DEST}"
+      else
+        mv "${chunk}" /buildout/"${DEST}".part${i}
+      fi
+    done
   else
     mv ${SRC} /buildout/"${DEST}"
   fi


### PR DESCRIPTION
## Summary

- Files >2 GiB are split into 2 GiB chunks for GitHub release upload
- Previous logic hardcoded `xaa`/`xab`/`xac` on the publish side and `.part2`/`.part3` on the `COMPRESS_INITRD` reshuffle side, **silently dropping** any further chunks (`xad+`, `.part4+`)
- Replaced both spots with counter loops so any number of parts is handled

## Why this matters

Caught while bringing up the new `omarchy` branch on `asset-mirror`. Omarchy's `airootfs.sfs` is ~5.86 GiB, which `split -b 2097151999` produces as **4** chunks (`xaa`, `xab`, `xac`, `xad`) — but only the first three were published. At boot the squashfs mount failed with `bad superblock` because the trailing index/metadata bytes were missing.

The deployed `archiso_pxe_http` hook already loops `.part2..N` until it hits a 404, so the client side handles arbitrary counts — only the server-side packaging needed updating.

## Behavior matrix

| airootfs size | Old behavior | New behavior |
|---|---|---|
| ≤ 2 GiB | single file | unchanged |
| 2-4 GiB | `airootfs.sfs` + `.part2` | unchanged |
| 4-6 GiB | `airootfs.sfs` + `.part2` + `.part3` | unchanged |
| 6-8 GiB | `airootfs.sfs` + `.part2` + `.part3` (xad dropped → corrupt) | `airootfs.sfs` + `.part2` + `.part3` + `.part4` |
| 8+ GiB | further parts dropped | all parts published |

## Test plan
- [x] Local rename-logic regression test for 2-part (cachyos), 3-part, and 4-part cases — all produce expected filenames
- [ ] Re-run `omarchy` workflow on `asset-mirror` after this image is rebuilt; verify all 4 parts published and live boot mounts squashfs cleanly