### PR TITLE
fix: detect single-layer initrds in unmkinitramfs path

### DIFF
--- a/root/build.sh
+++ b/root/build.sh
@@ -100,15 +100,26 @@ if [[ "${EXTRACT_INITRD}" == "true" ]];then
     mkdir -p initrd_extracted
     if unmkinitramfs ${INITRD_NAME} initrd_extracted/ 2>/dev/null; then
       mkdir -p initrd_files
-      # Merge all layers (early, early2, main, etc.) preserving drivers and modules
-      for layer in initrd_extracted/*/; do
-        if [ -d "$layer" ]; then
+      # unmkinitramfs has two output shapes:
+      #   - multi-layer initrd: extracts to early/, early2/, ..., main/
+      #   - single-layer initrd: extracts the cpio contents directly into the target,
+      #     so top-level entries are filesystem roots like bin/, etc/, sbin/.
+      # Detect by presence of main/, which is unmkinitramfs's signal for multi-layer mode.
+      if [ -d initrd_extracted/main ]; then
+        # Multi-layer: merge ordered layers, preserving microcode + drivers + main fs
+        for layer in initrd_extracted/early*/ initrd_extracted/main/; do
+          [ -d "$layer" ] || continue
           echo "Merging layer: $(basename $layer)"
           rsync -a "$layer" initrd_files/
-        fi
-      done
+        done
+        echo "Successfully extracted multi-layer initrd"
+      else
+        # Single-layer: extracted contents are already the initrd root
+        echo "Single-layer initrd, copying extracted contents"
+        rsync -a initrd_extracted/ initrd_files/
+        echo "Successfully extracted single-layer initrd"
+      fi
       rm -rf initrd_extracted
-      echo "Successfully extracted multi-layer initrd"
     else
       echo "unmkinitramfs failed, falling back to manual extraction"
       EXTRACT_MANUALLY=true


### PR DESCRIPTION
## Summary

- `unmkinitramfs` has two output shapes: multi-layer initrds extract to `early/`, `early2/`, ..., `main/`; single-layer initrds extract their cpio contents **directly** into the target, with top-level entries being filesystem roots (`bin/`, `etc/`, `sbin/`, ...).
- The current loop in `root/build.sh` iterates `initrd_extracted/*/` and treats every top-level directory as a layer. For single-layer initrds this misinterprets each filesystem root as a "layer" and rsync-merges their contents flat into `initrd_files/`, colliding `bin/cryptsetup` (executable) with `cryptroot/cryptsetup/` (directory) and failing with rsync exit 23.
- Fix: detect by presence of `initrd_extracted/main/` (unmkinitramfs's signal for multi-layer mode). Multi-layer path is preserved; single-layer initrds rsync the whole extracted tree across in one shot.

## Reproduction

The `netbootxyz/debian-squash` workflow `grml-small-amd64` failed on `grml-small-2026.04-amd64.iso` (single-cpio initrd):

```
Merging layer: bin
Merging layer: conf
Merging layer: cryptroot
Merging layer: etc
Merging layer: lib
Merging layer: lib64
Merging layer: run
Merging layer: sbin
could not make way for new regular file: cryptsetup
could not make way for new regular file: lvm
could not make way for new regular file: mdadm
cannot delete non-empty directory: cryptsetup
cannot delete non-empty directory: lvm
cannot delete non-empty directory: mdadm
rsync error: some files/attrs were not transferred (see previous errors) (code 23)
```

The "layer" names there are the actual initrd root directories — that's the smoking gun.

## Why not just add `--force` to rsync

`--force` would let rsync delete the existing non-empty directory and write the file in its place, silently destroying the contents of those directories (e.g., the `cryptsetup`/`lvm`/`mdadm` initramfs hook scripts and config). The directories and the binaries are legitimately distinct files in the source initrd; the bug is the loop, not rsync's safety check.

## Test plan

- [ ] Re-run `netbootxyz/debian-squash` `grml-small-amd64` workflow with a `latest` image built from this branch — initrd extraction succeeds, `initrd_files/` contains both `bin/cryptsetup` (file) and `cryptroot/cryptsetup/` (directory).
- [ ] Re-run a multi-layer build (e.g., `ubuntu-spins` / Clonezilla) — multi-layer path unchanged, kernel modules from `early2/` still preserved.
- [ ] Manual extraction fallback (`unmkinitramfs` not available, or fails) is untouched.